### PR TITLE
Treegen and rendering tweaks/fixes and cleanup

### DIFF
--- a/base/src/gen/plant/tree.rs
+++ b/base/src/gen/plant/tree.rs
@@ -173,7 +173,7 @@ impl TreeGen {
         // calculate the cross product between it and `parent_dir`.
         // This gets us a vector perpendicular to `parent_dir`, which we can rotate
         // `parent_dir` around to tilt it by `angle` degrees.
-        let mut rand_vec = Vector3f::rand(rng).normalize();
+        let mut rand_vec = Vector3f::rand(rng);
         while rand_vec.angle(parent_dir).approx_eq(&Rad::new(0.0)) {
             // They're parallel, so generate a new vector. This is probably unnecessary,
             // but someone
@@ -185,7 +185,7 @@ impl TreeGen {
         let rot_vec = parent_dir.cross(rand_vec);
 
         // Tilt the growing direction of the parent branch by about 90° to get the
-        // direction of the
+        // direction of the new branch
         let tilt_rotation = Basis3::from_axis_angle(rot_vec, Deg::new(angle).into());
 
         let spin_angle = range_sample(&(0.0..360.0), rng);

--- a/base/src/gen/plant/tree.rs
+++ b/base/src/gen/plant/tree.rs
@@ -1,12 +1,12 @@
 //! Generates random trees and tree-like plants.
 
 use prop::plant::{Branch, ControlPoint};
-use math::{ApproxEq, Basis3, Deg, Euler, InnerSpace, Point3f, Rad, Rotation, Rotation3, Vector1,
-           Vector3f};
+use math::*;
 use rand::{Rand, Rng};
 use rand::distributions::range::SampleRange;
 use rand::distributions::{self, IndependentSample};
 use std::ops::Range;
+use std::cmp;
 
 /// Parameters for the tree generator.
 #[derive(Debug)]
@@ -280,7 +280,9 @@ impl Rand for TreeGen {
 }
 
 /// Samples a random element from a range.
-fn range_sample<T: SampleRange + PartialOrd + Copy, R: Rng>(range: &Range<T>, rng: &mut R) -> T {
+fn range_sample<T: SampleRange + cmp::PartialOrd + Copy, R: Rng>(range: &Range<T>,
+                                                                 rng: &mut R)
+                                                                 -> T {
     // Build a `rand` crate Range. We use `std`s Range for the cool `a..b` syntax ;)
     distributions::Range::new(range.start, range.end).ind_sample(rng)
 }

--- a/base/src/gen/plant/tree.rs
+++ b/base/src/gen/plant/tree.rs
@@ -169,31 +169,7 @@ impl TreeGen {
         // `branch_angle_deg` specifies the angle range in degrees
         let angle = range_sample(&self.preset.branch_angle_deg, rng);
 
-        // AWESOME hack: Generate *any* vector that is not parallel to `parent_dir`,
-        // calculate the cross product between it and `parent_dir`.
-        // This gets us a vector perpendicular to `parent_dir`, which we can rotate
-        // `parent_dir` around to tilt it by `angle` degrees.
-        let mut rand_vec = Vector3f::rand(rng);
-        while rand_vec.angle(parent_dir).approx_eq(&Rad::new(0.0)) {
-            // They're parallel, so generate a new vector. This is probably unnecessary,
-            // but someone
-            // who *actually* knows their math instead of faking it should check.
-            rand_vec = Vector3f::rand(rng);
-        }
-
-        // Create vector around we'll tilt `parent_dir`
-        let rot_vec = parent_dir.cross(rand_vec);
-
-        // Tilt the growing direction of the parent branch by about 90° to get the
-        // direction of the new branch
-        let tilt_rotation = Basis3::from_axis_angle(rot_vec, Deg::new(angle).into());
-
-        let spin_angle = range_sample(&(0.0..360.0), rng);
-
-        // Then rotate this vector randomly (0-360°) around the parent branch
-        let around_we_go = Basis3::from_axis_angle(parent_dir, Deg::new(spin_angle).into());
-
-        around_we_go.rotate_vector(tilt_rotation.rotate_vector(parent_dir))
+        random_vec_with_angle(rng, parent_dir, angle)
     }
 
     fn create_trunk<R: Rng>(&mut self, rng: &mut R) {

--- a/base/src/gen/world/mod.rs
+++ b/base/src/gen/world/mod.rs
@@ -35,8 +35,9 @@ impl ChunkProvider for WorldGenerator {
                 let height = (((i as f32) * 0.25).sin() * 10.0 + ((j as f32) * 0.25).sin() * 10.0 +
                               100.0) as u16;
 
-                let ground_section =
-                    PillarSection::new(GroundMaterial::Dirt, HeightType(0), HeightType(height));
+                let ground_section = PillarSection::new(GroundMaterial::Dirt,
+                                                        HeightType::from_units(0),
+                                                        HeightType::from_units(height));
                 let mut props = Vec::new();
 
                 // Place a test plant every few blocks
@@ -46,7 +47,7 @@ impl ChunkProvider for WorldGenerator {
                     let gen = PlantGenerator::rand(&mut rng);
 
                     props.push(Prop {
-                        baseline: HeightType(height),
+                        baseline: HeightType::from_units(height),
                         prop: PropType::Plant(gen.generate(&mut rng)),
                     });
                 }

--- a/base/src/math/mod.rs
+++ b/base/src/math/mod.rs
@@ -7,11 +7,13 @@ extern crate cgmath;
 mod axial_point;
 mod axial_vector;
 mod dimension;
+mod random;
 
 pub use self::cgmath::*;
 pub use self::axial_vector::*;
 pub use self::axial_point::*;
 pub use self::dimension::*;
+pub use self::random::*;
 
 pub type DefaultFloat = f32;
 pub type DefaultInt = i32;

--- a/base/src/math/random.rs
+++ b/base/src/math/random.rs
@@ -1,0 +1,34 @@
+//! Utilities for random generation
+
+use math::*;
+
+use rand::{Rand, Rng};
+
+/// Generates a random `Vector3f` that has a specific angle to `v`.
+///
+/// The resulting vector will have a random rotation around `v`.
+pub fn random_vec_with_angle<R: Rng>(rng: &mut R, v: Vector3f, angle: f32) -> Vector3f {
+    // AWESOME hack: Generate *any* vector that is not parallel to `v`,
+    // calculate the cross product between it and `v`.
+    // This gets us a vector perpendicular to `v`, which we can rotate
+    // `v` around to tilt it by `angle` degrees.
+    let mut rand_vec = Vector3f::rand(rng);
+    while rand_vec.angle(v).approx_eq(&Rad::new(0.0)) {
+        // They're parallel, so generate a new vector. This is probably unnecessary,
+        // but someone who *actually* knows their math instead of faking it should
+        // check.
+        rand_vec = Vector3f::rand(rng);
+    }
+
+    // Create vector around we'll tilt `v`
+    let rot_vec = v.cross(rand_vec);
+
+    // Tilt `v` by `angle` to get some vector with the right angle
+    let tilt_rotation = Basis3::from_axis_angle(rot_vec, Deg::new(angle).into());
+
+    // Then rotate this vector randomly (0-360°) around `v`
+    let spin_angle = rng.gen_range(0.0, 360.0);
+    let around_we_go = Basis3::from_axis_angle(v, Deg::new(spin_angle).into());
+
+    around_we_go.rotate_vector(tilt_rotation.rotate_vector(v))
+}

--- a/base/src/world/ground.rs
+++ b/base/src/world/ground.rs
@@ -6,12 +6,12 @@ pub enum GroundMaterial {
 }
 
 impl GroundMaterial {
-    // Returns color of Texture in RGBA
-    pub fn get_color(&self) -> [f32; 4] {
+    // Returns color of Texture in RGB
+    pub fn get_color(&self) -> [f32; 3] {
         match *self {
-            GroundMaterial::Dirt => [0.37, 0.13, 0.001, 1.0],
-            GroundMaterial::Grass => [0.0, 0.5, 0.0, 1.0],
-            GroundMaterial::Stone => [0.5, 0.5, 0.5, 1.0],
+            GroundMaterial::Dirt => [0.37, 0.13, 0.001],
+            GroundMaterial::Grass => [0.0, 0.5, 0.0],
+            GroundMaterial::Stone => [0.5, 0.5, 0.5],
         }
     }
 }

--- a/base/src/world/mod.rs
+++ b/base/src/world/mod.rs
@@ -47,11 +47,21 @@ pub struct PillarIndex(pub math::AxialPoint);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ChunkIndex(pub math::AxialPoint);
 
-/// Represents one discrete height of a pillar section.
+/// Represents a discretized height.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub struct HeightType(pub u16);
+pub struct HeightType(u16);
 
 impl HeightType {
+    /// Creates a `HeightType` with a given discrete height.
+    pub fn from_units(n: u16) -> Self {
+        HeightType(n)
+    }
+
+    /// Gets the number of discrete units.
+    pub fn units(&self) -> u16 {
+        self.0
+    }
+
     /// Calculates the real (world position) height from the underlying
     /// representation.
     pub fn to_real(&self) -> f32 {

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -12,6 +12,7 @@ use std::io::{Read, Write};
 use self::toml::Value;
 use std::string::String;
 
+#[derive(Debug)]
 pub struct Config {
     pub resolution: Dimension2u,
     pub window_mode: WindowMode,
@@ -82,6 +83,8 @@ seed = 42
 
         let t_conf = try!(config_toml(conf, &matches));
         let conf_final = try!(config_command(t_conf, &matches));
+
+        debug!("final config: {:?}", conf_final);
         Ok(conf_final)
     }
 }
@@ -246,6 +249,8 @@ fn config_command(mut toml_config: Config, matches: &ArgMatches) -> Result<Confi
     }
     Ok(toml_config)
 }
+
+#[derive(Debug)]
 pub enum WindowMode {
     Windowed,
     // FullScreenWindow, // TODO: maybe add this

--- a/client/src/game.rs
+++ b/client/src/game.rs
@@ -8,7 +8,7 @@ use super::Config;
 use world::WorldView;
 use base::math::*;
 use base::gen::WorldGenerator;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 pub struct Game {
     #[allow(dead_code)]

--- a/client/src/game.rs
+++ b/client/src/game.rs
@@ -8,6 +8,7 @@ use super::Config;
 use world::WorldView;
 use base::math::*;
 use base::gen::WorldGenerator;
+use std::time::{Instant, Duration};
 
 pub struct Game {
     #[allow(dead_code)]
@@ -41,6 +42,8 @@ impl Game {
     /// components. This function should remain rather small, all heavy lifting
     /// should be done in other functions.
     pub fn run(mut self) -> Result<(), ()> {
+        let mut frames = 0;
+        let mut next_fps_measure = Instant::now() + Duration::from_secs(1);
         loop {
             try!(self.renderer.render(&self.world_view, &self.player.get_camera()));
             let event_resp = self.event_manager
@@ -49,6 +52,13 @@ impl Game {
                 break;
             }
             self.player.update();
+
+            frames += 1;
+            if next_fps_measure < Instant::now() {
+                info!("{} FPS", frames);
+                next_fps_measure = Instant::now() + Duration::from_secs(1);
+                frames = 0;
+            }
         }
 
         Ok(())

--- a/client/src/world/chunk_std.vert
+++ b/client/src/world/chunk_std.vert
@@ -4,14 +4,15 @@ in vec3 position;
 in vec3 color;
 out vec3 x_color;
 
-uniform vec2 offset;
+uniform vec3 offset;
 uniform mat4 proj_matrix;
 uniform mat4 view_matrix;
-uniform mat4 scale_matrix;
-uniform vec4 material_color;
+uniform float height;
+uniform vec3 material_color;
 
 void main() {
-    gl_Position = proj_matrix * view_matrix * transpose(scale_matrix) *
-    vec4(position.xy + offset, position.z, 1);
-    x_color = material_color.xyz * (sin(position.x)*sin(position.x));
+    gl_Position = proj_matrix * view_matrix *
+        vec4(position.xy + offset.xy, position.z * height + offset.z, 1);
+
+    x_color = material_color * abs(sin(position.x) * sin(position.x));
 }

--- a/client/src/world/chunk_std.vert
+++ b/client/src/world/chunk_std.vert
@@ -1,18 +1,21 @@
 #version 140
 
 in vec3 position;
-in vec3 color;
 out vec3 x_color;
 
+// Height in units, not world coordinates, since the "pillar prototype" has a
+// height of one unit.
+uniform float height;
 uniform vec3 offset;
 uniform mat4 proj_matrix;
 uniform mat4 view_matrix;
-uniform float height;
 uniform vec3 material_color;
 
 void main() {
     gl_Position = proj_matrix * view_matrix *
         vec4(position.xy + offset.xy, position.z * height + offset.z, 1);
 
+    // FIXME: Slightly modify the material color to create some color
+    // differences. Remove this once real lighting is used.
     x_color = material_color * abs(sin(position.x) * sin(position.x));
 }

--- a/client/src/world/chunk_view.rs
+++ b/client/src/world/chunk_view.rs
@@ -39,9 +39,7 @@ impl ChunkView {
             hexagon_vertex_buffer.push_front(Vertex {
                 position: [x, y, world::PILLAR_STEP_HEIGHT],
             });
-            hexagon_vertex_buffer.push_back(Vertex {
-                position: [x, y, 0.0],
-            });
+            hexagon_vertex_buffer.push_back(Vertex { position: [x, y, 0.0] });
 
         }
 

--- a/client/src/world/chunk_view.rs
+++ b/client/src/world/chunk_view.rs
@@ -38,11 +38,9 @@ impl ChunkView {
 
             hexagon_vertex_buffer.push_front(Vertex {
                 position: [x, y, world::PILLAR_STEP_HEIGHT],
-                color: [0.15 * i as f32, 0.0, 0.0],
             });
             hexagon_vertex_buffer.push_back(Vertex {
                 position: [x, y, 0.0],
-                color: [1.0 - 0.15 * i as f32, 0.15 * i as f32, 0.0],
             });
 
         }
@@ -124,15 +122,13 @@ impl ChunkView {
 }
 
 
-// FIXME `Vertex` really shouldn't be in this module
-
+/// Vertex type used to render chunks (or hex pillars).
 #[derive(Debug, Copy, Clone)]
 pub struct Vertex {
     pub position: [f32; 3],
-    pub color: [f32; 3],
 }
 
-implement_vertex!(Vertex, position, color);
+implement_vertex!(Vertex, position);
 
 pub struct PillarView {
     pos: Point2f,

--- a/client/src/world/chunk_view.rs
+++ b/client/src/world/chunk_view.rs
@@ -89,14 +89,11 @@ impl ChunkView {
     pub fn draw<S: glium::Surface>(&self, surface: &mut S, camera: &Camera) {
         for pillar in &self.pillars {
             for section in &pillar.sections {
-                let scale_matrix =
-                    Matrix4::from_nonuniform_scale(1.0,
-                                                   1.0,
-                                                   section.top.0 as f32 - section.bottom.0 as f32) *
-                    Matrix4::from_translation(Vector3f::new(0.0, 0.0, section.bottom.0 as f32));
-                let uniforms = uniform!{
-                    scale_matrix: scale_matrix.to_arr(),
-                    offset: [pillar.pos.x, pillar.pos.y],
+                let height = section.top.units() - section.bottom.units();
+
+                let uniforms = uniform! {
+                    height: height as f32,
+                    offset: [pillar.pos.x, pillar.pos.y, section.bottom.to_real()],
                     proj_matrix: camera.proj_matrix().to_arr(),
                     view_matrix: camera.view_matrix().to_arr(),
                     material_color: section.ground.get_color(),
@@ -153,7 +150,7 @@ impl PillarView {
                 .map(|prop| {
                     match prop.prop {
                         PropType::Plant(ref plant) => {
-                            let pos = Point3f::new(pos.x, pos.y, prop.baseline.0 as f32);
+                            let pos = Point3f::new(pos.x, pos.y, prop.baseline.to_real());
                             PlantView::from_plant(pos, plant, facade)
                         }
                     }

--- a/client/src/world/plant_view.rs
+++ b/client/src/world/plant_view.rs
@@ -5,7 +5,6 @@ use Camera;
 use render::ToArr;
 use base::math::*;
 use base::prop::Plant;
-use world::chunk_view::Vertex;
 
 /// Graphical representation of a 'base::Plant'
 pub struct PlantView {
@@ -80,3 +79,12 @@ impl PlantView {
         }
     }
 }
+
+/// Vertex type used to render plants/trees.
+#[derive(Debug, Copy, Clone)]
+pub struct Vertex {
+    pub position: [f32; 3],
+    pub color: [f32; 3],
+}
+
+implement_vertex!(Vertex, position, color);

--- a/client/src/world/plant_view.rs
+++ b/client/src/world/plant_view.rs
@@ -56,8 +56,7 @@ impl PlantView {
 
     pub fn draw<S: glium::Surface>(&self, surface: &mut S, camera: &Camera) {
         let uniforms = uniform! {
-            // FIXME HACK why do i have to half the Z coordinate...
-            offset: [self.pos.x, self.pos.y, self.pos.z/2.0],
+            offset: self.pos.to_arr(),
             proj_matrix: camera.proj_matrix().to_arr(),
             view_matrix: camera.view_matrix().to_arr(),
         };


### PR DESCRIPTION
* `debug!` the config we use
* Fix growing of new tree branches
 * Their growing direction wasn't randomized properly
* Higher chance of growing branches out of the trunk
* Stop extending branches when they have a diameter of <1mm
* Add an FPS counter which prints the FPS to the console every second
* Make `HeightType` a tiny bit less confusing
* Chunk rendering: Drop the `scale_matrix` and pass a `height` instead
* Make material colors RGB instead of RGBA
 * The shader ignored the Alpha channel anyways
 * I'm not convinced that we need or want transparent ground