### PR TITLE
Use 3 codegen units.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ path = "client"
 
 [dependencies.server]
 path = "server"
+
+[profile.release]
+codegen-units = 3


### PR DESCRIPTION
On my desktop PC (4+4 cores i7), this decreased the compile times after
changing `client` from 19.9 to 9.8 seconds (!).